### PR TITLE
update config scope type to string array from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Documentation links:
    - `target_app_signature`: SHA256 fingerprint for your app's signature
      ([how do I find this?](https://developers.google.com/android/guides/client-auth))
    - `client_id`: Client id configured with App Flip for your app
-   - `scope`: Optional additional auth scopes configured with App Flip for your app
+   - `scope`: Optional additional auth scopes array configured with App Flip for your app
 1. Build and run the app on your target device
 
 ## Usage

--- a/app/src/main/java/com/google/appfliptesttool/MainActivity.java
+++ b/app/src/main/java/com/google/appfliptesttool/MainActivity.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
+import android.content.res.Resources;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -57,7 +58,7 @@ public class MainActivity extends AppCompatActivity {
   private static final int APP_FLIP_INVALID_REQUEST_ERROR = 3;
   private static final int APP_FLIP_USER_DENIED_3P_CONSENT_ERROR_CODE = 13;
   private static final int RC_APP_FLIP = 100;
-  private String scopes;
+  private String[] scopes;
   private String redirectUri;
   private TextView logTextView;
   private EditText appNameToFlip, clientID, signatureEditText, intentFilterName;
@@ -68,6 +69,7 @@ public class MainActivity extends AppCompatActivity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
+    Resources res = getResources();
     Button appFlipButton = findViewById(R.id.flipButton);
     logTextView = findViewById(R.id.resultText);
     appNameToFlip = findViewById(R.id.appIdEditText);
@@ -75,7 +77,7 @@ public class MainActivity extends AppCompatActivity {
     context = getApplicationContext();
     signatureEditText = findViewById(R.id.signatureEditText);
     clientID = findViewById(R.id.clientIdEditText);
-    scopes = getString(R.string.scope);
+    scopes = res.getStringArray(R.array.scope);
     redirectUri = getString(R.string.redirect_uri);
 
     appFlipButton.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,9 @@
     <string name="intent_filter_name">com.google.appflip-sample</string>
     <string name="target_app_signature">54:e1:6a:b5:4c:cb:75:13:7d:cf:2a:4c:37:97:e4:5f:28:42:76:0a:6f:ce:c7:04:5f:49:0b:24:08:e7:e3:5e</string>
     <string name="client_id">1234</string>
-    <string name="scope">scope1</string>
+    <string-array name="scope">
+        <item>scope1</item>
+    </string-array>
     <string name="redirect_uri">http://google.com/oauth/</string>
     <!--Labels-->
     <string name="app_name">AppFlip Test Tool</string>


### PR DESCRIPTION
This PR updates the `scope` config type to match official Account Linking documentation.

In the [Android Account Linking documentation](https://developers.google.com/identity/account-linking/app-flip-android#content_of_the_launch_intent), the expected value type of `scope` is `ArrayList<String>`. Previously we were only reading a single `String` value. This change updates the `scope` type to be a `String[]`. This change matches the documentation and expected type from the App Flip SDK.